### PR TITLE
add cubeviz and mosviz launch notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/02_Jdaviz/CubevizDemo.ipynb
+++ b/02_Jdaviz/CubevizDemo.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cubeviz Demonstration Notebook\n",
+    "\n",
+    "This notebook demonstrates the Cubeviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Cubeviz, can be found here: https://jdaviz.readthedocs.io/en/latest/cubeviz/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: We silence most warnings for now. For debugging, you can comment out the next cell and then restart the kernel to re-enable warnings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.simplefilter('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from jdaviz import Cubeviz\n",
+    "from astropy.utils.data import download_file\n",
+    "\n",
+    "viz = Cubeviz()\n",
+    "\n",
+    "# This file is originally from https://data.sdss.org/sas/dr14/manga/spectro/redux/v2_1_2/7495/stack/manga-7495-12704-LOGCUBE.fits.gz\n",
+    "# but has been modified to correct some inconsistencies in the way units are parsed\n",
+    "fn = download_file('https://stsci.box.com/shared/static/28a88k1qfipo4yxc4p4d40v4axtlal8y.fits', cache=True)\n",
+    "viz.load_data(fn)\n",
+    "\n",
+    "viz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thank you!\n",
+    "Thank you for attending Space Telescope Science Institute's Data Analysis Tools Workshop at the 239th Meeting of the American Astronomical Society! We hope you found this session informative and our tools useful for your analysis.\n",
+    "\n",
+    "* Documentation: https://jdaviz.readthedocs.io/\n",
+    "* GitHub: https://github.com/spacetelescope/jdaviz\n",
+    "* Report an issue directly to us: https://github.com/spacetelescope/jdaviz/issues/new/choose\n",
+    "* JWST Help Desk: https://stsci.service-now.com/jwst"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/02_Jdaviz/MosvizDemo.ipynb
+++ b/02_Jdaviz/MosvizDemo.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mosviz Demonstration Notebook\n",
+    "\n",
+    "This notebook demonstrates the Mosviz API in the Notebook setting. UI equivalents for these actions, as well as additional documentation about Mosviz, can be found here: https://jdaviz.readthedocs.io/en/latest/mosviz/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: We silence most warnings for now. For debugging, you can comment out the next cell and then restart the kernel to re-enable warnings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.simplefilter('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll download and load an example data set.  For more examples of for loading MOS data, see the [Mosviz Example Notebook](https://github.com/spacetelescope/jdaviz/blob/main/notebooks/MosvizExample.ipynb) or the [Mosviz NIRISS Example Notebook](https://github.com/spacetelescope/jdaviz/blob/main/notebooks/MosvizNIRISSExample.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from jdaviz import Mosviz\n",
+    "from zipfile import ZipFile\n",
+    "from astropy.utils.data import download_file\n",
+    "import pathlib\n",
+    "import tempfile\n",
+    "\n",
+    "data_dir = tempfile.gettempdir()\n",
+    "\n",
+    "example_data = 'https://stsci.box.com/shared/static/ovyxi5eund92yoadvv01mynwt8t5n7jv.zip'\n",
+    "fn = download_file(example_data, cache=True)\n",
+    "with ZipFile(fn, 'r') as sample_data_zip:\n",
+    "    sample_data_zip.extractall(data_dir)\n",
+    "    \n",
+    "data_dir = (pathlib.Path(data_dir) / 'mosviz_nirspec_data_0.3' / 'level3')\n",
+    "\n",
+    "mosviz = Mosviz()\n",
+    "mosviz.load_data(directory=data_dir, instrument=\"nirspec\")\n",
+    "mosviz.app"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thank you!\n",
+    "Thank you for attending Space Telescope Science Institute's Data Analysis Tools Workshop at the 239th Meeting of the American Astronomical Society! We hope you found this session informative and our tools useful for your analysis.\n",
+    "\n",
+    "* Documentation: https://jdaviz.readthedocs.io/\n",
+    "* GitHub: https://github.com/spacetelescope/jdaviz\n",
+    "* Report an issue directly to us: https://github.com/spacetelescope/jdaviz/issues/new/choose\n",
+    "* JWST Help Desk: https://stsci.service-now.com/jwst"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds slimmed down versions of the usual example notebooks along with links to docs etc.  Also adds a gitignore for `.ipynb_checkpoints`.