### PR TITLE
Remove astropy-helpers

### DIFF
--- a/00_Installation/pre-requirements.txt
+++ b/00_Installation/pre-requirements.txt
@@ -1,3 +1,2 @@
 wheel
 numpy==1.18.5
-astropy-helpers==2.0.11


### PR DESCRIPTION
It is no longer supported by the Astropy project and is never meant to be installed directly like this.