### PR TITLE
Environment Validation improvements

### DIFF
--- a/00_Installation/README.md
+++ b/00_Installation/README.md
@@ -52,7 +52,7 @@ If you do not have git installed you will need to [install git]().  Once you hav
 These packages are reqorded in the requirements files in this directory, and can be installed using pip.
 
 You will need python version **3.8.10**. 
-We recommend using the following command sequence, to creates a conda environment and prepare it for installation  
+We recommend using the following command sequence to creates a conda environment and prepare it for installation  
 
 ```
 % conda create -n aas239-jwebbinar python=3.8.10 pip wheel numpy

--- a/00_Installation/README.md
+++ b/00_Installation/README.md
@@ -52,7 +52,7 @@ If you do not have git installed you will need to [install git]().  Once you hav
 These packages are reqorded in the requirements files in this directory, and can be installed using pip.
 
 You will need python version **3.8.10**. 
-We recommend using the following command sequence to creates a conda environment and prepare it for installation  
+We recommend using the following command sequence to create a conda environment and prepare it for installation  
 
 ```
 % conda create -n aas239-jwebbinar python=3.8.10 pip wheel numpy

--- a/00_Installation/README.md
+++ b/00_Installation/README.md
@@ -52,12 +52,21 @@ If you do not have git installed you will need to [install git]().  Once you hav
 These packages are reqorded in the requirements files in this directory, and can be installed using pip.
 
 You will need python version **3.8.10**. 
-We recommend the following command sequence, which creates a conda environment and installs the requirements into it.  
+We recommend using the following command sequence, to creates a conda environment and prepare it for installation  
 
 ```
 % conda create -n aas239-jwebbinar python=3.8.10 pip wheel numpy
 % conda activate aas239-jwebbinar
 % pip install -r pre-requirements.txt
+```
+
+Afterwards, please install the main requirements file. If you are on a Windows machine (not installing within the Windows Subsystem for Linux), please run our specific windows requirements file
+```
+% pip install -r requirements_windows.txt
+```
+
+Otherwise, on macOS or a Linux distribution (or on Windows within a Windows Subsystem for Linux):
+```
 % pip install -r requirements.txt
 ```
 

--- a/00_Installation/README.md
+++ b/00_Installation/README.md
@@ -75,7 +75,7 @@ Otherwise, on macOS or a Linux distribution (or on Windows within a Windows Subs
 Run the `ValidateEnvironment.ipynb` notebook to test that your installation works.
 
 ```
-% cd aas239-jwebbinar
+% cd ..
 % jupyter notebook ValidateEnvironment.ipynb
 ```
 

--- a/00_Installation/requirements_windows.txt
+++ b/00_Installation/requirements_windows.txt
@@ -1,0 +1,15 @@
+scipy>=1.7.1
+photutils>=1.1.0
+scikit-image>=0.16.2
+astropy==4.3.1
+specutils>=1.4.0
+matplotlib>=3.4.3
+Bottleneck>=1.3.2
+ipyvue>=1.5.0
+ipyvuetify>=1.8.1
+aplpy >= 2.0.3
+jwst == 1.3.1
+stdatamodels == 0.2.2
+git+https://github.com/spacetelescope/jdaviz.git@main
+git+https://github.com/radio-astro-tools/radio-beam.git
+jupyter

--- a/ValidateEnvironment.ipynb
+++ b/ValidateEnvironment.ipynb
@@ -42,6 +42,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbe419b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specviz = Specviz()\n",
+    "specviz.app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c67ce5d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosviz = Mosviz()\n",
+    "mosviz.app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "749ec365",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "imviz.app"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d31b10a7",
    "metadata": {},


### PR DESCRIPTION
This PR:
- Adds a requirements.txt file specifically for Windows, which pins `jwst` and `stdatamodels` to older versions due to https://github.com/spacetelescope/jwst/issues/6466
- Updates the README to add these installation instructions for Windows
- Loads Specviz, Mosviz, and Imviz to the validation notebook in order to load the JS files